### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/ly-holiday/security/code-scanning/8](https://github.com/legnoh/ly-holiday/security/code-scanning/8)

To fix the problem, you should add a `permissions` block with the minimal required permissions to either the root of the workflow file (to apply to all jobs) or directly inside the specific job(s). The safest minimal permission is `contents: read`, which allows jobs to fetch repository contents (e.g., with checkout or for reading files) but does not allow writing or making any repository changes. If individual steps or jobs require additional permissions, those can be granted more narrowly at the job level. For this workflow, there is no indication that broader permissions (such as `pull-requests: write`) are needed, so the correct fix is to add `permissions: contents: read` after the workflow `name` field and before the `on:` field.

**Changes to make:**
- In `.github/workflows/ci.yml`, add a block as follows:
  ```yaml
  permissions:
    contents: read
  ```
  Place this right after the `name: CI` line and before the `on:` key.

**No extra methods or libraries are required for this fix; it is a direct YAML edit.**

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
